### PR TITLE
Fixed deep clone where strings were getting confuged.

### DIFF
--- a/test/duxml/doc/element_test.rb
+++ b/test/duxml/doc/element_test.rb
@@ -87,6 +87,11 @@ class ElementTest < Test::Unit::TestCase
     x << '<fifth/>'
     assert_equal '<fifth/>', x.fifth.to_s
   end
+  
+  def test_add_xml_from_str_mixed
+    x << "<new_test>See <ph audience=\"internal\">Something here</ph> cool things.</new_test>"
+    assert_equal "<new_test>See <ph audience=\"internal\">Something here</ph> cool things.</new_test>", x.new_test.to_s
+  end
 
   def test_delete_attr
     assert_equal '<root foot="poot"/>', x.stub.to_s


### PR DESCRIPTION
When I was working with this gem in another Ruby application, a test I wrote showed the following:

Input Stream:
`<element1>Text1<element2 attr2>Text2</element2>Text3</element1>`

With previous dclone, it returned:
`<element1>Text1<element2 attr2>Text2Text3</element2></element1>`

not what was expected.  This should allow all previous dclones to work.

@ludocracy for some reason, I can't get test to run, but the test I added should catch this from popping up again.